### PR TITLE
Avoid xochitl.service ever starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ systemctl daemon-reload
 
 # WARNING: after the next step, xochitl (on plaintext home directory)
 # won't start by default anymore
-systemctl disable xochitl --now
+systemctl mask xochitl --now
 
 # after this step the screen will become blank
 systemctl enable framebufferserver --now


### PR DESCRIPTION
On reboot, observed a case where despite being disabled, the xochitl.service unit started up leading to a confused display.

framebufferserver.service lists xochitl.service in its Before statement, so this may be the cause.

Masking xochitl.service is a stronger rule. Haven't seen the issue since implementing this.