### PR TITLE
Upgrade to go 1.19.5 and add GH Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build Docker image
+      run: docker build -t remarkable-crypto-toolchain .
+    - name: Build project
+      run: docker run --rm -i -u $(id -u):$(id -g) -v $(pwd):/project remarkable-crypto-toolchain make

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ qrc_qml.cpp
 /remarkable-crypto-files.tar.gz
 Vagrantfile
 .vagrant
+/.cache
+/go
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 FROM ghcr.io/toltec-dev/qt:v2.1
 
+ARG GO_VERSION=1.19.5
+
 RUN cd /root \
     && curl --proto '=https' --tlsv1.2 -sSf \
-        https://dl.google.com/go/go1.16.3.linux-amd64.tar.gz \
-        -o go1.16.3.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf go1.16.3.linux-amd64.tar.gz \
+        https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
+        -o go${GO_VERSION}.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz \
     && mkdir go \
-    && rm go1.16.3.linux-amd64.tar.gz
+    && rm go${GO_VERSION}.linux-amd64.tar.gz
 
 ENV PATH="$PATH:/usr/local/go/bin"
-ENV GOPATH="/root/go"
 
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \
@@ -19,5 +20,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 RUN mkdir /project
 
 WORKDIR /project
+
+ENV HOME=/project
 
 CMD make

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ on the `toltec` Qt `Dockerfile` and adds Go 1.16, `git` and `wget`.
 
 ```bash
 docker build -t remarkable-crypto-toolchain .
-docker run --rm -it -v $(pwd):/project remarkable-crypto-toolchain make
+docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):/project remarkable-crypto-toolchain make
 ```
 
 Alternatively, the components of this project can be built separately with the


### PR DESCRIPTION
Upgrades to go 1.19.5 and adds GH Actions to test the build automatically.

Also uses the invoking user id to avoid having files created by root on the host. Works on Linux and should work on Mac. Unsure about Windows admittedly.