### PR TITLE
Adds instructions for enabling cloud sync

### DIFF
--- a/contrib/sync/README.md
+++ b/contrib/sync/README.md
@@ -1,0 +1,14 @@
+# Enabling cloud sync with cryptodaemon
+
+Warning: files are only encrypted on the local device and at rest on the
+reMarkable Cloud. If you wish to use cloud sync with cryptodaemon, then ennsure
+this suits your use case and threat model.
+
+## Setup
+
+* Ensure `xochitl.service` and `sync.service` are masked.
+* Copy `sync-crypto.service` to `/etc/systemd/system`.
+  * e.g. `scp contrib/sync/sync-crypto.service root@remarkable.local:/etc/systemd/system/`
+* Add `Wants=sync-crypto.service` to `/etc/systemd/system/cryptodaemon.service`
+* `systemctl daemon-reload`
+* `systemctl enable sync-crypto --now`

--- a/contrib/sync/sync-crypto.service
+++ b/contrib/sync/sync-crypto.service
@@ -1,0 +1,26 @@
+# Same as the upstream sync.service unit, except we change the After, BindsTo
+# and PartOf directives
+
+[Unit]
+Description=reMarkable Document Sync
+After=dbus.socket
+StartLimitIntervalSec=60
+StartLimitBurst=4
+After=cryptodaemon.service
+BindsTo=cryptodaemon.service
+PartOf=cryptodaemon.service
+
+[Service]
+# Do NOT make this dbus, until we review the crash handling, as disassociating
+# from this busname will result in systemd killing sync for Type=dbus (by design)
+# Type=dbus
+Type=simple
+BusName=no.remarkable.sync
+ExecStart=/usr/bin/sync --service
+Restart=on-failure
+# No matter the signal, we want it to restart (all of these kill sync, but are
+# considered a "successful" termination (without restart) by systemd otherwise).
+RestartForceExitStatus=SIGHUP SIGINT SIGTERM SIGPIPE
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I know Cloud Sync is out of scope for the project. However would it be OK to merge some instructions to enable it for folks that want local file encryption in case the device is lost/stolen, but are willing to accept the reMarkable Cloud attack vector?